### PR TITLE
build: Update rocm-docs-core to 1.4.1

### DIFF
--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core[api_reference]==1.4.0
+rocm-docs-core[api_reference]==1.4.1

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -41,9 +41,9 @@ docutils==0.21.2
     #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
-doxysphinx==3.3.8
+doxysphinx==3.3.9
     # via rocm-docs-core
-fastjsonschema==2.19.1
+fastjsonschema==2.20.0
     # via rocm-docs-core
 gitdb==4.0.11
     # via gitpython
@@ -83,7 +83,7 @@ packaging==24.1
     #   sphinx
 pycparser==2.22
     # via cffi
-pydata-sphinx-theme==0.15.3
+pydata-sphinx-theme==0.15.4
     # via
     #   rocm-docs-core
     #   sphinx-book-theme
@@ -112,7 +112,7 @@ requests==2.32.3
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core[api-reference]==1.4.0
+rocm-docs-core[api-reference]==1.4.1
     # via -r requirements.in
 smmap==5.0.1
     # via gitdb
@@ -161,7 +161,7 @@ typing-extensions==4.12.2
     # via
     #   pydata-sphinx-theme
     #   pygithub
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   pygithub
     #   requests


### PR DESCRIPTION
For the header update (GitHub link will direct to this repository instead of ROCm/ROCm)