### PR TITLE
Add the Radeon Pro W7900 Dual Slot to table of Windows-supported GPUs

### DIFF
--- a/docs/reference/system-requirements.rst
+++ b/docs/reference/system-requirements.rst
@@ -39,6 +39,7 @@ If a GPU is not listed on this table, it is not officially supported by AMD.
       :widths: 20, 20, 20, 20, 20
       :header: "Name", "Architecture", "LLVM target", "Runtime", "HIP SDK"
 
+      "AMD Radeon PRO W7900 Dual Slot", "RDNA3", "gfx1100", "✅", "✅"
       "AMD Radeon PRO W7900", "RDNA3", "gfx1100", "✅", "✅"
       "AMD Radeon PRO W7800", "RDNA3", "gfx1100", "✅", "✅"
       "AMD Radeon PRO W7700", "RDNA3", "gfx1101", "✅", "✅"


### PR DESCRIPTION
This fix adds the Radeon Pro W7900 Dual Slot to the AMD Radeon Pro tab of the Windows Supported GPUs table. The specs are copied from the Radeon Pro W7900 entry. This follows the example from the same SKU entry for Linux