### PR TITLE
Quick hack to hardcode header version to 6.2.4

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,8 @@ rst_prolog = f"""
 .. |win_rocm_version| replace:: {win_rocm_version}
 """
 
+html_static_path = ["sphinx/static/js"]
+html_js_files = ["fix-version-header.js"]
 html_theme_options = {
     "link_main_doc": True
 }

--- a/docs/sphinx/static/js/fix-version-header.js
+++ b/docs/sphinx/static/js/fix-version-header.js
@@ -1,0 +1,16 @@
+// FIXME: TEMPORARY quick hack to pin the version in header in the "latest" branch
+
+function ready(callback) {
+	if (document.readyState !== "loading") {
+		callback();
+		return;
+	}
+	document.addEventListener("DOMContentLoaded", callback);
+}
+
+ready(() => {
+	const rocmHeader = document.querySelector(
+		"div.header-logo a[href='https://rocm.docs.amd.com/en/latest']",
+	);
+	rocmHeader.textContent = "ROCm™ Software 6.2.4"
+});


### PR DESCRIPTION
The docs site for the `latest` branch pulls the header version from https://github.com/ROCm/rocm-docs-core/blob/data/latest_version.txt. The HIP SDK docs latest version is not aligned with the rest of ROCm.

This js is a temporary dirty fix until a permanent fix in rocm-docs-core is made.